### PR TITLE
:sparkles: Feat: 거래글 관련 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 application.yml
+
+src/main/resources/static/uploads/*

--- a/sql/purchase.sql
+++ b/sql/purchase.sql
@@ -1,0 +1,54 @@
+select
+    a.id,
+    a.latitude,
+    a.longitude,
+    a.title,
+    a.place,
+    a.date,
+    a.price,
+    a.denominator,
+    a.numerator,
+    a.status,
+    (
+        select
+            count(*)
+        from
+            nthing.like b
+        where true
+            and b.user_id = 3
+            and b.purchase_id = a.id
+    ) as is_liked
+from
+    nthing.purchase as a
+
+# insert
+INSERT INTO nthing.purchase
+    (
+     title,
+     description,
+     latitude,
+     longitude,
+     date,
+     denominator,
+     numerator,
+     status,
+     price,
+     place,
+     updated_at,
+     manager_id
+     )
+VALUES
+    (
+    '양말 20켤레 공동구매',
+    '신촌역 앞에서 양말 20켤레씩 싸게 파는데 전 5켤레만 필요해서 나머지 15켤레 구매하실분들 구합니다',
+     '2.2',
+     '2.2',
+     '2023-07-11 18:00:00',
+     '5',
+     '20',
+     '0',
+     '2000',
+     '신촌역 2번출구 앞',
+     '2023-07-07 08:33:22',
+     '1'
+     );

--- a/src/main/java/com/nthing/nthing/NthingApplication.java
+++ b/src/main/java/com/nthing/nthing/NthingApplication.java
@@ -4,7 +4,6 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 
 @SpringBootApplication
 @ComponentScan({"data.*"})

--- a/src/main/java/data/Service/PurchaseService.java
+++ b/src/main/java/data/Service/PurchaseService.java
@@ -1,0 +1,42 @@
+package data.Service;
+
+import data.dto.PurchaseDto;
+import data.mapper.PurchaseMapper;
+import data.util.FileUploadUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Service
+public class PurchaseService {
+
+    private final PurchaseMapper purchaseMapper;
+
+    @Autowired
+    public PurchaseService(PurchaseMapper purchaseMapper) {
+        this.purchaseMapper = purchaseMapper;
+    }
+
+    public void createPurchase(PurchaseDto.Request purchase) {
+        purchaseMapper.createPurchase(purchase);
+    }
+
+    public List<PurchaseDto.Summary> findAllPurchase(HashMap<String, Object> map) {
+        return purchaseMapper.findAllPurchase(map);
+    }
+
+    public PurchaseDto.Detail findPurchaseById(int id) {
+        return purchaseMapper.findPurchaseById(id);
+    }
+
+    public void updatePurchase(PurchaseDto.Request purchase) {
+        purchaseMapper.updatePurchase(purchase);
+    }
+
+    public void deletePurchase(int id) {
+        FileUploadUtil.deleteFile(findPurchaseById(id).getImage());
+        purchaseMapper.deletePurchase(id);
+    }
+}

--- a/src/main/java/data/controller/PurchaseController.java
+++ b/src/main/java/data/controller/PurchaseController.java
@@ -1,0 +1,63 @@
+package data.controller;
+
+import data.Service.PurchaseService;
+import data.dto.PurchaseDto;
+import data.util.FileUploadUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.List;
+
+@RestController
+public class PurchaseController {
+
+    private final PurchaseService purchaseService;
+
+    @Autowired
+    public PurchaseController(PurchaseService purchaseService) {
+        this.purchaseService = purchaseService;
+    }
+
+    @PostMapping("/purchase")
+    public void createPurchase(
+            @RequestParam(value = "image", required = false) MultipartFile imageFile,
+            @ModelAttribute PurchaseDto.Request purchaseRequest
+    ) {
+        purchaseService.createPurchase(purchaseRequest);
+    }
+
+    @GetMapping("/purchases")
+    public List<PurchaseDto.Summary> findAllPurchase(String search_keyword, String sort) {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("search_keyword", search_keyword);
+        map.put("sort", sort);
+        return purchaseService.findAllPurchase(map);
+    }
+
+    @GetMapping("/purchase/{id}")
+    public PurchaseDto.Detail findById(@PathVariable int id) {
+        return purchaseService.findPurchaseById(id);
+    }
+
+    @PatchMapping("/purchase")
+    public void updatePurchase(
+            @RequestParam(value = "image", required = false) MultipartFile imageFile,
+            @ModelAttribute PurchaseDto.Request purchaseRequest
+    ){
+        PurchaseDto.Detail purchase = purchaseService.findPurchaseById(purchaseRequest.getId());
+
+        if(StringUtils.hasText(purchase.getImage())) {
+            FileUploadUtil.deleteFile(purchase.getImage());
+        }
+
+        purchaseService.updatePurchase(purchaseRequest);
+    }
+
+    @DeleteMapping("/purchase/{id}")
+    public void deletePurchase(@PathVariable int id) {
+        purchaseService.deletePurchase(id);
+    }
+}

--- a/src/main/java/data/dto/CategoryDto.java
+++ b/src/main/java/data/dto/CategoryDto.java
@@ -1,0 +1,13 @@
+package data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CategoryDto {
+    private int id;
+    private String name;
+}

--- a/src/main/java/data/dto/CollegeDto.java
+++ b/src/main/java/data/dto/CollegeDto.java
@@ -8,6 +8,7 @@ import org.apache.ibatis.type.Alias;
 public class CollegeDto {
     private int id;
     private String name;
+    private String address;
     private Float latitude;
     private Float longitude;
 }

--- a/src/main/java/data/dto/LikeDto.java
+++ b/src/main/java/data/dto/LikeDto.java
@@ -6,9 +6,9 @@ import lombok.Data;
 import org.apache.ibatis.type.Alias;
 
 @Data
-@Alias("PurchaseUserDto")
+@Alias("LikeDto")
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-public class PurchaseUserDto {
+public class LikeDto {
     private int id;
     private int userId;
     private int purchaseId;

--- a/src/main/java/data/dto/PurchaseDto.java
+++ b/src/main/java/data/dto/PurchaseDto.java
@@ -1,26 +1,112 @@
 package data.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Data;
-import org.apache.ibatis.type.Alias;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import data.util.FileUploadUtil;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.sql.Timestamp;
 
-@Data
-@Alias("PurchaseDto")
 public class PurchaseDto {
-    private int id;
-    private String title;
-    private String description;
-    private Float latitude;
-    private Float longitude;
-    private Timestamp purchaseDate;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-    private int totalNumber;
-    private int managerNumber;
-    private boolean status;
-    private int price;
-    private String address;
-    private String detailedAddress;
-    private int managerId;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Info {
+        private int id;
+        private String title;
+        private String description;
+        private Float latitude;
+        private Float longitude;
+        private Timestamp date;
+        private int denominator;
+        private int numerator;
+        private boolean status;
+        private int price;
+        private String place;
+        private String image;
+        private Timestamp updatedAt;
+        private int managerId;
+        private int categoryId;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Request {
+        private int id;
+        private String title;
+        private String description;
+        private Float latitude;
+        private Float longitude;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private Timestamp date;
+        private int denominator;
+        private int numerator;
+        private int price;
+        private String place;
+        private String image;
+        private int manager_id;
+        private int category_id;
+
+        public void setImage(MultipartFile imageFile) {
+            if(!imageFile.isEmpty()) {
+                try {
+                    this.image = FileUploadUtil.uploadFile(imageFile);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    public static class Summary {
+        private int id;
+        private String title;
+        private Float latitude;
+        private Float longitude;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private Timestamp date;
+        private int denominator;
+        private int numerator;
+        private int price;
+        private String place;
+        private boolean status;
+        private String image;
+        private boolean isLiked;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    public static class Detail {
+        private int id;
+        private String title;
+        private String description;
+        private Float latitude;
+        private Float longitude;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private Timestamp date;
+        private int denominator;
+        private int numerator;
+        private boolean status;
+        private int price;
+        private String place;
+        private String image;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private Timestamp updatedAt;
+        private int managerId;
+        private int categoryId;
+        private String categoryName;
+        private boolean isLiked;
+    }
 }

--- a/src/main/java/data/dto/UserDto.java
+++ b/src/main/java/data/dto/UserDto.java
@@ -1,6 +1,8 @@
 package data.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import org.apache.ibatis.type.Alias;
 
@@ -8,14 +10,15 @@ import java.sql.Timestamp;
 
 @Data
 @Alias("UserDto")
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class UserDto {
     private int id;
     private String nickname;
     private String email;
     private String password;
-    private String profile_image;
+    private String profileImage;
     private int credit;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private Timestamp subscriptionDate;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private int collegeId;
 }

--- a/src/main/java/data/mapper/PurchaseMapper.java
+++ b/src/main/java/data/mapper/PurchaseMapper.java
@@ -1,0 +1,16 @@
+package data.mapper;
+
+import data.dto.PurchaseDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Mapper
+public interface PurchaseMapper {
+    void createPurchase(PurchaseDto.Request purchase);
+    List<PurchaseDto.Summary> findAllPurchase(HashMap<String, Object> map);
+    PurchaseDto.Detail findPurchaseById(int id);
+    void updatePurchase(PurchaseDto.Request purchase);
+    void deletePurchase(int id);
+}

--- a/src/main/java/data/util/FileUploadUtil.java
+++ b/src/main/java/data/util/FileUploadUtil.java
@@ -1,0 +1,50 @@
+package data.util;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+public class FileUploadUtil {
+
+    private static final String UPLOAD_DIR = "src/main/resources/static/uploads";
+
+    public static String uploadFile(MultipartFile file) throws IOException {
+        String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
+        String fileName = generateUniqueFileName(originalFilename);
+        Path uploadPath = Path.of(UPLOAD_DIR);
+
+        if (!Files.exists(uploadPath)) {
+            Files.createDirectories(uploadPath);
+        }
+
+        Path filePath = uploadPath.resolve(fileName);
+
+        try (InputStream inputStream = file.getInputStream()) {
+            Files.copy(inputStream, filePath, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        return fileName;
+    }
+
+    public static void deleteFile(String fileName) {
+        File file = new File(UPLOAD_DIR+"/"+fileName);
+
+        if(file.exists()) {
+            file.delete();
+            System.out.println(fileName+" file delete");
+        }
+    }
+
+    private static String generateUniqueFileName(String originalFilename) {
+        String extension = StringUtils.getFilenameExtension(originalFilename);
+        String uniqueFileName = UUID.randomUUID().toString() + "." + extension;
+        return uniqueFileName;
+    }
+}

--- a/src/main/resources/mapper/PurchaseSql.xml
+++ b/src/main/resources/mapper/PurchaseSql.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="data.mapper.PurchaseMapper">
+    <insert id="createPurchase" parameterType="data.dto.PurchaseDto$Request">
+        insert into nthing.purchase
+        (
+            title
+            ,description
+            ,latitude
+            ,longitude
+            ,date
+            ,denominator
+            ,numerator
+            ,price
+            ,place
+            ,image
+            ,manager_id
+            ,category_id
+            ,status
+            ,updated_at
+        )
+        values
+        (
+            #{title}
+            ,#{description}
+            ,#{latitude}
+            ,#{longitude}
+            ,#{date}
+            ,#{denominator}
+            ,#{numerator}
+            ,#{price}
+            ,#{place}
+            ,#{image}
+            ,#{manager_id}
+            ,#{category_id}
+            ,0
+            ,now()
+        )
+    </insert>
+    <select id="findAllPurchase" resultType="data.dto.PurchaseDto$Summary" parameterType="map">
+        select
+            a.id
+            ,a.title
+            ,a.latitude
+            ,a.longitude
+            ,a.date
+            ,a.denominator
+            ,a.numerator
+            ,a.price
+            ,a.place
+            ,a.status
+            ,a.image
+            ,(
+                select
+                    count(*)
+                from
+                    nthing.like b
+                where true
+                  and b.user_id = #{user_id}
+                  and b.purchase_id = a.id
+            ) as is_liked
+        from
+            nthing.purchase as a
+        <where>
+            <if test="search_keyword != null and search_keyword != ''">
+                a.title like CONCAT('%',#{search_keyword},'%')
+            </if>
+        </where>
+        <if test="sort != null and sort != ''">
+            order by ${sort}
+        </if>
+    </select>
+    <select id="findPurchaseById" resultType="data.dto.PurchaseDto$Detail" parameterType="int">
+        select
+            a.id
+            ,a.title
+            ,a.description
+            ,a.latitude
+            ,a.longitude
+            ,a.date
+            ,a.denominator
+            ,a.numerator
+            ,a.status
+            ,a.price
+            ,a.place
+            ,a.image
+            ,a.updated_at
+            ,a.manager_id
+            ,a.category_id
+            ,c.name as category_name
+            ,(
+                select
+                    count(*)
+                from
+                    nthing.like b
+                where true
+                  and b.user_id = 3
+                  and b.purchase_id = a.id
+            ) as is_liked
+        from
+            nthing.purchase as a
+            left join category c on a.category_id = c.id
+        where
+            a.id = #{id}
+    </select>
+    <update id="updatePurchase" parameterType="data.dto.PurchaseDto$Request">
+        update purchase
+        set
+            title = #{title}
+            ,description = #{description}
+            ,latitude = #{latitude}
+            ,longitude = #{longitude}
+            ,date = #{date}
+            ,denominator = #{denominator}
+            ,numerator = #{numerator}
+            ,price = #{price}
+            ,place = #{place}
+            ,image = #{image}
+            ,category_id = #{category_id}
+        where
+            id = #{id}
+            and manager_id = #{manager_id}
+    </update>
+    <delete id="deletePurchase" parameterType="int">
+        delete from purchase where id = #{id}
+    </delete>
+</mapper>


### PR DESCRIPTION
### 거래글 생성
- 클라이언트에서 요청받는 폼 데이터를 `@ModelAttribut`를 이용하여 객체가 전달되도록 구현
- 이미지 첨부
  - 요청시 이미지 타입(MultiparFile)과 거래글 객체의 타입(String : 파일 이름)이 달라 Dto에 이미지 업로드 및 변환 로직 반영
  1. `@RequestParam`으로 MultipartFile 타입으로 받은 후
  2. `PurchaseDto.Request`에서 `setImage()`에서 파입 업로드 및 파일 이름 반환
  3. 반환된 파일 이름 `PurchaseDto.Request` 객체에 적용 후 Service에 전달

### 거래글 조회
- 목록
  - 검색어 필터, 정렬 기능 구현 (Query Parameter)
- 상세
  - 거래글 id를 Path Parameter 받아서 응답

### 거래글 업데이트
- 거래글 생성과 동일
- 이미지 파일의 업데이트 발생시 이전 이미지 파일은 삭제 되도록 구현

### 거래글 삭제
- 거래글 삭제시 이미지 파일도 삭제 되도록 구현

***

### 기타
- `PurchaseDto` Inner Class 설정
  - Info, Request, Summary, Detail
  - 필요에 맞는 데이터 응답
  - DTO 패키지 관리 용이

- util/FileUploadUtil 클래스 생성
  - 톰캣의 `resources/static/uploads`에 저장되도록 구현
  - 생성, 삭제 메서드 구현
  - 추후 S3 등 스토리지 적용시 맞게 수정 예정

- service 패키지 설정
  - service에서 비즈니르 로직 구현